### PR TITLE
Update README.md, fix possible naming collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,39 +4,140 @@ Theia Edition contains only the Terminal over HTTP standard components.
 
 It is good for getting shell access to the target environment such as Kubernetes.
 
+<!-- TOC -->
+* [codbex-theia](#codbex-theia)
+    * [Run steps](#run-steps)
+        * [Start using Docker and released image](#start-using-docker-and-released-image)
+        * [Start using Docker and local sources](#start-using-docker-and-local-sources)
+            * [Build the project jar](#build-the-project-jar)
+            * [Build and run docker image locally](#build-and-run-docker-image-locally)
+        * [Java standalone application](#java-standalone-application)
+            * [Start the application](#start-the-application)
+            * [Start the application **in debug** with debug port `8000`](#start-the-application-in-debug-with-debug-port-8000)
+        * [Run unit tests](#run-unit-tests)
+        * [Run integration tests](#run-integration-tests)
+        * [Run all tests](#run-all-tests)
+        * [Format the code](#format-the-code)
+    * [Access the application](#access-the-application)
+    * [REST API](#rest-api)
+<!-- TOC -->
 
-#### Docker
+## Run steps
 
-```
-docker pull ghcr.io/codbex/codbex-theia:latest
-docker run --name codbex-theia --rm -p 80:80 ghcr.io/codbex/codbex-theia:latest
-```
+__Prerequisites:__
+- Export the following variables before executing the steps
+  ```shell
+  export GIT_REPO_FOLDER='<path-to-the-git-repo>'
+  export IMAGE='ghcr.io/codbex/codbex-theia:latest'
+  export CONTAINER_NAME='theia'
+  ```
 
-#### Build
+### Start using Docker and released image
 
-```
-mvn clean install
-```
-	
-#### Run
+```shell
+# optionally remove the existing container with that name
+docker rm -f "$CONTAINER_NAME"
+docker pull "$IMAGE"
 
-```
-java -jar application/target/codbex-theia-application-*.jar
-```
-
-#### Debug
-
-```
-java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000 -jar application/target/codbex-theia-application-*.jar
-```
-	
-#### Web
-
-```
-http://localhost
+docker run --name "$CONTAINER_NAME" -p 80:80 "$IMAGE"
 ```
 
-#### REST API
+---
+
+### Start using Docker and local sources
+#### Build the project jar
+```shell
+cd $GIT_REPO_FOLDER
+mvn -T 1C clean install -P quick-build
+```
+
+#### Build and run docker image locally
+
+__Prerequisites:__ [Build the project jar](#build-the-project-jar)
+
+  ```shell
+  cd "$GIT_REPO_FOLDER/application"
+  
+  docker build . --tag "$IMAGE"
+  
+  # optionally remove the existing container with that name
+  docker rm -f "$CONTAINER_NAME"
+
+  docker run --name "$CONTAINER_NAME" -p 80:80 "$IMAGE"
+  ```
+
+--- 
+
+### Java standalone application
+__Prerequisites:__ [Build the project jar](#build-the-project-jar)
+
+#### Start the application
+```shell
+cd "$GIT_REPO_FOLDER"
+
+java \
+    --add-opens=java.base/java.lang=ALL-UNNAMED \
+    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+    --add-opens=java.base/java.nio=ALL-UNNAMED \
+    -jar application/target/codbex-theia-*.jar
+```
+
+#### Start the application **in debug** with debug port `8000`
+```shell
+cd "$GIT_REPO_FOLDER"
+
+export PHOEBE_AIRFLOW_WORK_DIR="$AIRFLOW_WORK_DIR"
+java \
+    -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000 \
+    --add-opens=java.base/java.lang=ALL-UNNAMED \
+    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+    --add-opens=java.base/java.nio=ALL-UNNAMED \
+    -jar application/target/codbex-theia-*.jar
+```
+
+---
+
+### Run unit tests
+
+```shell
+cd "$GIT_REPO_FOLDER"
+mvn clean install -P unit-tests
+```
+
+---
+
+### Run integration tests
+
+```shell
+cd "$GIT_REPO_FOLDER"
+mvn clean install -P integration-tests
+```
+
+---
+
+### Run all tests
+
+```shell
+cd "$GIT_REPO_FOLDER"
+mvn clean install -P tests
+```
+
+---
+
+### Format the code
+
+```shell
+cd "$GIT_REPO_FOLDER"
+mvn verify -P format
+```
+
+---
+
+## Access the application
+- Open URL [http://localhost:80](http://localhost:80)
+- Login with the default credentials username `admin` and password `admin`
+
+## REST API
 
 ```
 http://localhost/swagger-ui/index.html

--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -8,6 +8,6 @@ RUN npm i -g typescript
 RUN apk add git
 RUN apk --no-cache add msttcorefonts-installer fontconfig && update-ms-fonts && fc-cache -f
 
-COPY target/*.jar codbex-theia.jar
+COPY target/codbex-theia-[0-9]*.jar codbex-theia.jar
 ENTRYPOINT ["java", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "-jar", "/codbex-theia.jar"]
 EXPOSE 80 8081

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -120,6 +120,10 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>

--- a/application/src/main/java/com/codbex/theia/AppLifecycleLoggingListener.java
+++ b/application/src/main/java/com/codbex/theia/AppLifecycleLoggingListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 codbex or an codbex affiliate company and contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 codbex or an codbex affiliate company and contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package com.codbex.theia;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Order(Ordered.LOWEST_PRECEDENCE)
+@Component
+class AppLifecycleLoggingListener implements ApplicationListener<ApplicationEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppLifecycleLoggingListener.class);
+
+    @Override
+    public void onApplicationEvent(ApplicationEvent event) {
+        if (event instanceof ApplicationReadyEvent) {
+            LOGGER.info("------------------------ Theia started ------------------------");
+        }
+        if (event instanceof ContextClosedEvent) {
+            LOGGER.info("------------------------ Theia stopped ------------------------");
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codbex.platform</groupId>
         <artifactId>codbex-platform-parent</artifactId>
-        <version>10.6.50</version>
+        <version>11.1.2</version>
     </parent>
 
     <name>codbex - theia - parent</name>


### PR DESCRIPTION
Update README.md, fix possible naming collisions when starting with java -jar and during the Docker build